### PR TITLE
Add OS-aware clipboard copying and Linux clipboard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This script supports both encrypted and plain-text token files, but my reccomend
 
 * oathtool (http://www.nongnu.org/oath-toolkit/)
 * OpenSSL
-
+* xclip (Linux)
 
 ## Description
 
@@ -50,7 +50,7 @@ The number on the left is the seconds counter; a new TOTP token is generated eve
 
 The number on the right is the 6-digit One-Time Password.
 
-On MacOS, this will be copied directly into the paste buffer. Just press "Command-V" to paste into a login dialog.
+This will be copied directly into the paste buffer. Just press "Command-V" (or "CTRL-V" on Linux) to paste into a login dialog.
 
 
 ## Contents

--- a/otp.sh
+++ b/otp.sh
@@ -57,6 +57,11 @@ while true; do
     else
         echo -ne "$D: $X\r"
     fi
-    echo -n $X | pbcopy
+    OS=$( uname )
+    if [[ $OS = "Darwin" ]]; then
+        echo -n $X | pbcopy
+    elif [[ $OS = "Linux" ]]; then
+        echo -n $X | xclip -sel clip
+    fi
     sleep 1
 done


### PR DESCRIPTION
This commit will allow Linux users to use the script without a problem, including copy-to-clipboard. It also has a safeguard whereby if the user is invoking the script from a system other than macOS or Linux (e.g. BSD), the script will not error out.