### PR TITLE
Add modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,39 @@
 # bash-otp
 One-Time Password generator for CLI using bash, oathtool.
 
-Automatically copys the token into your computer's copy buffer (MacOS only atm)
-
 This is basically "Authy for the CLI"
 
-This script supports both encrypted and plain-text token files, but my reccomendation is to use encryption.
+Automatically copies (using modifier "-c") the token into your computer's copy buffer
+
+This script supports both encrypted and plain-text token files, but my recommendation is to use encryption.
 
 ### Requirements
 
 * oathtool (http://www.nongnu.org/oath-toolkit/)
 * OpenSSL
 * xclip (Linux)
+* pbcopy (MacOS)
 
 ## Description
 
 Set of bash shell scripts to generate OTP *value* from token using TOTP.
 
-### Usage
+### Setup
 
-First ensure that there is a directory "tokenfiles" in the main dir where the script resides.
+First ensure that there is a directory "**tokenfiles**" in you **$HOME** directory or in the main directory where the script resides.
 
 1. Create token file and encrypt it. Resulting file, "tokenfiles/tokenname.enc", is an encrypted file containing the token
   1. Put your token in a plaintext file in the tokenfiles/ directory:
   ```bash
   $ echo "1234567890abcdef" > tokenfiles/tokenname
   ```
-  
+
   1. Encrypt the file with the included shell script:
   ```bash
   $ ./otp-lockfile.sh tokenfiles/tokenname
   Password: (enter a good password)
   ```
-  
+
   1. Confirm it worked:
   ```bash
   $ ls tokenfiles/
@@ -42,7 +43,7 @@ First ensure that there is a directory "tokenfiles" in the main dir where the sc
 1. Run otp.sh; will produce roughly the following output:
   ```
 $ ./otp.sh tokenname
-Password:
+OTP Password:
 02: 123456
   ```
 
@@ -50,8 +51,15 @@ The number on the left is the seconds counter; a new TOTP token is generated eve
 
 The number on the right is the 6-digit One-Time Password.
 
-This will be copied directly into the paste buffer. Just press "Command-V" (or "CTRL-V" on Linux) to paste into a login dialog.
+### Usage
 
+```
+./otp.sh [-1] [-c] [-s] <Token Name>
+
+ -1 : Get 1 password and exit.
+ -c : Copy to clipboard. This will be copied directly into the paste buffer. Just paste it anywhere.
+ -s : Silent. Do not output anything to console.
+```
 
 ## Contents
 
@@ -59,4 +67,3 @@ This will be copied directly into the paste buffer. Just press "Command-V" (or "
 * Script to encrypt the token in a file
 * Script to decrypt same
 * Empty "tokenfiles/" directory
-

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ One-Time Password generator for CLI using bash, oathtool.
 
 This is basically "Authy for the CLI"
 
-Automatically copies (using modifier "-c") the token into your computer's copy buffer
+Automatically copies the token into your computer's copy buffer. Just paste it anywhere.
 
 This script supports both encrypted and plain-text token files, but my recommendation is to use encryption.
 
@@ -54,10 +54,10 @@ The number on the right is the 6-digit One-Time Password.
 ### Usage
 
 ```
-./otp.sh [-1] [-c] [-s] <Token Name>
+./otp.sh [-1] [-n] [-s] <Token Name>
 
  -1 : Get 1 password and exit.
- -c : Copy to clipboard. This will be copied directly into the paste buffer. Just paste it anywhere.
+ -n : Do not copy to clipboard.
  -s : Silent. Do not output anything to console.
 ```
 

--- a/otp-lockfile.sh
+++ b/otp-lockfile.sh
@@ -10,27 +10,27 @@ set -e
 #openssl enc -aes-256-cbc -d -salt -in file.txt.enc -out file.txt
 
 INPUT_FILE="$1"
-PW_FILE=$( mktemp pwfile.XXXXXXXX )
-
-echo "WARNING: THIS WILL DELETE THE ORIGINAL FILE"
 
 if [ ! -f "${INPUT_FILE}" ]; then
     echo "The file [${INPUT_FILE}] does not exist"
     exit 1
 fi
 
+
+echo "WARNING: THIS WILL DELETE THE ORIGINAL FILE"
+
 read -s -r -p "Password to lock file: " PASSWORD1
+echo
 read -s -r -p "Enter that password again: " PASSWORD2
+echo
 
 if [[ "${PASSWORD1}" == "${PASSWORD2}" ]]; then
-
-    echo "${PASSWORD1}" > "${PW_FILE}"
-    openssl enc -aes-256-cbc -salt -in "${INPUT_FILE}" -out "${INPUT_FILE}.enc" -pass file:"${PW_FILE}" && rm "${INPUT_FILE}" && rm "${PW_FILE}"
-    echo "Decrypt this file using the following command:"
-    echo "openssl enc -aes-256-cbc -d -salt -in ${INPUT_FILE}.enc -out ${INPUT_FILE}"
+  PW_FILE=$( mktemp pwfile.XXXXXXXX )
+  echo "${PASSWORD1}" > "${PW_FILE}"
+  openssl enc -aes-256-cbc -salt -in "${INPUT_FILE}" -out "${INPUT_FILE}.enc" -pass file:"${PW_FILE}" && rm "${INPUT_FILE}" && rm "${PW_FILE}" && chmod 400 "${INPUT_FILE}.enc"
+  echo "Decrypt this file using the following command:"
+  echo "openssl enc -aes-256-cbc -d -salt -in ${INPUT_FILE}.enc -out ${INPUT_FILE}"
 else
-    echo "The passwords do not match; try that again"
-    rm "${PW_FILE}"
-    exit 1
+  echo "The passwords do not match; try that again"
+  exit 1
 fi
-

--- a/otp-unlockfile.sh
+++ b/otp-unlockfile.sh
@@ -18,7 +18,6 @@ if [ ! -f "${INPUT_FILE}" ]; then
     exit 1
 fi
 
-
 read -s -r -p "Password to unlock file: " PASSWORD1
 
 OUTPUT_FILE=$( echo $INPUT_FILE | sed 's/.enc//' )

--- a/otp-unlockfile.sh
+++ b/otp-unlockfile.sh
@@ -12,15 +12,17 @@ set -e
 #openssl enc -aes-256-cbc -d -salt -in file.txt.enc -out file.txt
 
 INPUT_FILE="$1"
-OUTPUT_FILE=$( echo $INPUT_FILE | sed 's/.enc//' )
-PW_FILE=$( mktemp pwfile.XXXXXXXX )
 
 if [ ! -f "${INPUT_FILE}" ]; then
     echo "The file [${INPUT_FILE}] does not exist"
     exit 1
 fi
 
+
 read -s -r -p "Password to unlock file: " PASSWORD1
+
+OUTPUT_FILE=$( echo $INPUT_FILE | sed 's/.enc//' )
+PW_FILE=$( mktemp pwfile.XXXXXXXX )
 
 echo "${PASSWORD1}" > "${PW_FILE}"
 openssl enc -aes-256-cbc -d -salt -in "${INPUT_FILE}" -out "${OUTPUT_FILE}" -pass file:"${PW_FILE}"

--- a/otp.sh
+++ b/otp.sh
@@ -9,8 +9,8 @@
 #openssl enc -aes-256-cbc -d -salt -in file.txt.enc -out file.txt
 
 function validate_modifiers {
-  if [[ $MODIFIERS == *c* ]]; then
-    CLIPBOARD=true
+  if [[ $MODIFIERS == *n* ]]; then
+    NO_CLIPBOARD=true
   fi
   if [[ $MODIFIERS == *1* ]]; then
     ONE_TIME=true
@@ -74,16 +74,18 @@ function verify_command {
 }
 
 function copy_to_clipboard {
-  if [ "$X" != "$LAST_PASSWORD" ]; then
-    OS=$( uname )
-    if [[ $OS = "Darwin" ]]; then
-      verify_command "pbcopy"
-      echo -n $X | pbcopy
-    elif [[ $OS = "Linux" ]]; then
-      verify_command "xclip"
-      echo -n $X | xclip -sel clip
+  if [ "$NO_CLIPBOARD" != "true" ]; then
+    if [ "$X" != "$LAST_PASSWORD" ]; then
+      OS=$( uname )
+      if [[ $OS = "Darwin" ]]; then
+        verify_command "pbcopy"
+        echo -n $X | pbcopy
+      elif [[ $OS = "Linux" ]]; then
+        verify_command "xclip"
+        echo -n $X | xclip -sel clip
+      fi
+      LAST_PASSWORD="$X"
     fi
-    LAST_PASSWORD="$X"
   fi
 }
 
@@ -104,10 +106,10 @@ function set_tokenfiles_dir {
 
 function show_usage {
   echo "ERROR: $1"
-  echo "Usage: $( basename ${0} ) [-1] [-c] [-s] <Token Name>"
+  echo "Usage: $( basename ${0} ) [-1] [-n] [-s] <Token Name>"
   echo
   echo " -1 : Get 1 password and exit."
-  echo " -c : Copy to clipboard. This will be copied directly into the paste buffer. Just paste it anywhere."
+  echo " -n : Do not copy to clipboard."
   echo " -s : Silent. Do not output anything to console."
   exit 1
 }
@@ -140,9 +142,7 @@ while true; do
   D="$( date  +%S )"
   X=$( oathtool --totp -b "$TOKEN" )
 
-  if [ $CLIPBOARD ]; then
-    copy_to_clipboard $X
-  fi
+  copy_to_clipboard $X
 
   echo -ne "$D: $X\r" > $( echo "$OUTPUT" )
 

--- a/otp.sh
+++ b/otp.sh
@@ -9,17 +9,23 @@
 #openssl enc -aes-256-cbc -d -salt -in file.txt.enc -out file.txt
 
 function validate_modifiers {
-  if [[ $MODIFIERS == *n* ]]; then
-    NO_CLIPBOARD=true
-  fi
-  if [[ $MODIFIERS == *1* ]]; then
-    ONE_TIME=true
-  fi
-  if [[ $MODIFIERS == *s* ]]; then
-    OUTPUT="/dev/null"
-  else
-    OUTPUT="/dev/stdout"
-  fi
+  OUTPUT="/dev/stdout"
+
+  while [ $# -gt 1 ]
+  do
+    if [[ "$1" == "-n" ]]; then
+      NO_CLIPBOARD=true
+    fi
+    if [[ "$1" == "-1" ]]; then
+      ONE_TIME=true
+    fi
+    if [[ "$1" == "-s" ]]; then
+      OUTPUT="/dev/null"
+    fi
+    shift
+  done
+
+  [[ $1 != -* ]] && TOKEN_NAME="$1"
 }
 
 function check_permissions {
@@ -123,13 +129,13 @@ fi
 
 set_tokenfiles_dir
 
-PARAMETERS=( "$@" )
-TOKEN_NAME="${PARAMETERS[${#PARAMETERS[@]}-1]}"
+validate_modifiers $@
 
-unset "PARAMETERS[${#PARAMETERS[@]}-1]"
-MODIFIERS=${PARAMETERS[@]}
+if [ -z "$TOKEN_NAME" ]; then
+  show_usage "Missing Token Name"
+  exit 1
+fi
 
-validate_modifiers
 check_permissions $TOKENFILES_DIR "700"
 check_file
 get_token

--- a/otp.sh
+++ b/otp.sh
@@ -134,6 +134,10 @@ check_permissions $TOKENFILES_DIR "700"
 check_file
 get_token
 
+if [[ ! $TOKEN =~ ^[0-9A-Z]+$ ]]; then
+  exit 1
+fi
+
 echo > $( echo "$OUTPUT" )
 
 LAST_PASSWORD=0

--- a/otp.sh
+++ b/otp.sh
@@ -8,60 +8,128 @@
 # Decrypt file to file
 #openssl enc -aes-256-cbc -d -salt -in file.txt.enc -out file.txt
 
-# Init
-TOKENFILES_DIR="$( dirname ${0} )/tokenfiles"
-TOKENFILES_DIR_MODE="$( ls -ld ${TOKENFILES_DIR} | awk '{print $1}'| sed 's/.//' )"
-U_MODE="$( echo $TOKENFILES_DIR_MODE | gawk  -F '' '{print $1 $2 $3}' )"
-G_MODE="$( echo $TOKENFILES_DIR_MODE | gawk  -F '' '{print $4 $5 $6}' )"
-A_MODE="$( echo $TOKENFILES_DIR_MODE | gawk  -F '' '{print $7 $8 $9}' )"
-
-if [ "$( echo $G_MODE | egrep 'r|w|x' )" -o "$( echo $A_MODE | egrep 'r|w|x' )" ]; then
-    echo "Perms on [${TOKENFILES_DIR}] are too permissive. Try 'chmod 700 ${TOKENFILES_DIR}' first"
-    exit 1
-fi
-
-token="$1"
-if [ -z "$token" ]; then echo "Need token filename"; exit 1; fi
-
-# Returns the token
-function get_decrypted_token_from_file {
-    read -s -r -p "Password: " PASSWORD
-    echo $PASSWORD | openssl enc -aes-256-cbc -d -salt -pass stdin -in ${TOKENFILES_DIR}/${token}.enc
+function validate_modifiers {
+  if [[ $MODIFIERS == *c* ]]; then
+    CLIPBOARD=true
+  fi
+  if [[ $MODIFIERS == *1* ]]; then
+    ONE_TIME=true
+  fi
+  if [[ $MODIFIERS == *s* ]]; then
+    OUTPUT="/dev/null"
+  else
+    OUTPUT="/dev/stdout"
+  fi
 }
 
-function get_plaintext_token_from_file {
-    cat ${TOKENFILES_DIR}/$token
+function check_permissions {
+  TOKENFILES_DIR_MODE="$( ls -ldH $TOKENFILES_DIR | awk '{print $1}'| sed 's/.//' )"
+  U_MODE="$( echo $TOKENFILES_DIR_MODE | gawk  -F '' '{print $1 $2 $3}' )"
+  G_MODE="$( echo $TOKENFILES_DIR_MODE | gawk  -F '' '{print $4 $5 $6}' )"
+  A_MODE="$( echo $TOKENFILES_DIR_MODE | gawk  -F '' '{print $7 $8 $9}' )"
+
+  if [ "$( echo $G_MODE | egrep 'r|w|x' )" -o "$( echo $A_MODE | egrep 'r|w|x' )" ]; then
+    echo "Perms on [$TOKENFILES_DIR] are too permissive. Try 'chmod 700 $TOKENFILES_DIR' first"
+    exit 1
+  fi
 }
 
-if [[ -f "${TOKENFILES_DIR}/${token}.enc" ]]; then
-    TOKEN=$( get_decrypted_token_from_file $token )
-elif [[ -f "${TOKENFILES_DIR}/${token}" ]]; then
-    TOKEN=$( get_plaintext_token_from_file $token )
-else
-    echo "ERROR: Key file [${TOKENFILES_DIR}/$token] doesn't exist"
-    exit 1
-fi
+function decrypt_token_from_file {
+  read -s -r -p "OTP Password: " PASSWORD
+  echo $PASSWORD | openssl enc -aes-256-cbc -d -salt -pass stdin -in $1
+}
 
-#TOKEN=$( get_decrypted_token_from_file $token )
-echo
-D=0
-D="$( date  +%S )"
-if [ $D -gt 30 ] ; then D=$( echo "$D - 30"| bc ); fi
-if [ $D -lt 0 ] ; then D="00"; fi
+function plaintext_token_from_file {
+  cat $1
+}
 
-while true; do
-    D="$( date  +%S )"
-    X=$( oathtool --totp -b "$TOKEN" )
-    if [ $D = '59'  -o $D = '29' ] ; then
-        echo "$D: $X"
-    else
-        echo -ne "$D: $X\r"
+function check_file {
+  TOKEN_PATH=${TOKENFILES_DIR}/${TOKEN_NAME}
+  FILES=("${TOKEN_PATH}.enc" "${TOKEN_PATH}")
+
+  for file in ${FILES[@]}; do
+    if [[ -f "${file}" ]]; then
+      TOKEN_FILE="${file}"
+      return 0
     fi
+  done
+
+  echo "ERROR: Token files [${FILES[@]}] doesn't exist"
+  exit 1
+}
+
+function get_token {
+  if [[ ${TOKEN_FILE} == *.enc ]]; then
+    TOKEN=$( decrypt_token_from_file $TOKEN_FILE )
+  else
+    TOKEN=$( plaintext_token_from_file $TOKEN_FILE )
+  fi
+}
+
+function verify_clip_command {
+  command -v $1 >/dev/null 2>&1 || { echo >&2 "Required '$1'. Install it and try again."; echo "Aborting."; exit 1; }
+}
+
+function copy_to_clipboard {
+  if [ "$X" != "$LAST_PASSWORD" ]; then
     OS=$( uname )
     if [[ $OS = "Darwin" ]]; then
-        echo -n $X | pbcopy
+      verify_clip_command "pbcopy"
+      echo -n $X | pbcopy
     elif [[ $OS = "Linux" ]]; then
-        echo -n $X | xclip -sel clip
+      verify_clip_command "xclip"
+      echo -n $X | xclip -sel clip
     fi
-    sleep 1
+    LAST_PASSWORD="$X"
+  fi
+}
+
+function show_usage {
+  echo "ERROR: $1"
+  echo "Usage: ./otp.sh [1cs] <Token Name>"
+  echo
+  echo " 1 : Get 1 password and exit"
+  echo " c : Copy to clipboard"
+  echo " s : Silent"
+  exit 1
+}
+
+if [ "$#" == 0 ]; then
+  show_usage "Missing parameters"
+fi
+
+PARAMETERS=( "$@" )
+TOKEN_NAME="${PARAMETERS[${#PARAMETERS[@]}-1]}"
+
+unset "PARAMETERS[${#PARAMETERS[@]}-1]"
+MODIFIERS=${PARAMETERS[@]}
+
+OTP_HOME="$( echo ${HOME} || dirname ${0} )"
+TOKENFILES_DIR="${OTP_HOME}/tokenfiles"
+
+#Init
+check_permissions
+check_file
+validate_modifiers
+get_token
+
+echo > $( echo "$OUTPUT" )
+
+LAST_PASSWORD=0
+
+while true; do
+  D="$( date  +%S )"
+  X=$( oathtool --totp -b "$TOKEN" )
+
+  if [ $CLIPBOARD ]; then
+    copy_to_clipboard $X
+  fi
+
+  echo -ne "$D: $X\r" > $( echo "$OUTPUT" )
+
+  if [ $ONE_TIME ]; then
+    echo "$D: $X" > $( echo "$OUTPUT" )
+    exit 0;
+  fi
+  sleep 1
 done

--- a/otp.sh
+++ b/otp.sh
@@ -104,11 +104,11 @@ function set_tokenfiles_dir {
 
 function show_usage {
   echo "ERROR: $1"
-  echo "Usage: ./otp.sh [1cs] <Token Name>"
+  echo "Usage: $( basename ${0} ) [-1] [-c] [-s] <Token Name>"
   echo
-  echo " 1 : Get 1 password and exit"
-  echo " c : Copy to clipboard"
-  echo " s : Silent"
+  echo " -1 : Get 1 password and exit."
+  echo " -c : Copy to clipboard. This will be copied directly into the paste buffer. Just paste it anywhere."
+  echo " -s : Silent. Do not output anything to console."
   exit 1
 }
 


### PR DESCRIPTION
Added modifiers to help creating automated scripts like:
```
otp -1 -s my_token && ssh <my_server_with_otp>
```
This way, I only need to press `CMD+V` when server asks for OTP.

An example output:
```
> otp -1 -s my_token && ssh <my_server_with_otp>
OTP Password:

!!!This server requires OTP!!!

Verification code: <CMD+V>
Password:
```

CHANGELOG
==========

* Added modifiers
Modifiers for: 
- Single password display: Show a password and exit
- Do not copy to clipboard: Just show the password
- Silent mode: Do not output results

* Token files from $HOME
The support for Token files from user's $HOME directory enables the possibility to use the script system-wide.
Like, you can create a symbolic link from `/usr/bin` and use from anywhere!

* Do not copy same password again
The `copy-to-clipboard` will be called only when the password changes, avoiding always updating the buffer.

* Added helper message
```
Usage: otp [-1] [-n] [-s] <Token Name>

 -1 : Get 1 password and exit.
 -n : Do not copy to clipboard.
 -s : Silent. Do not output anything to console.
```

