### PR TITLE
Configurable "tokenfiles" directory via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Set of bash shell scripts to generate OTP *value* from token using TOTP.
 
 ### Usage
 
-First ensure that there is a directory "tokenfiles" in the main dir where the script resides.
+First ensure that there is a directory "tokenfiles" in the main dir where the script resides, and that this directory's permissions are set to 700.
 
 1. Create token file and encrypt it. Resulting file, "tokenfiles/tokenname.enc", is an encrypted file containing the token
   1. Put your token in a plaintext file in the tokenfiles/ directory:
@@ -52,6 +52,12 @@ The number on the right is the 6-digit One-Time Password.
 
 This will be copied directly into the paste buffer. Just press "Command-V" (or "CTRL-V" on Linux) to paste into a login dialog.
 
+
+In case you want "tokenfiles" to reside in a different location, you can tell otp.sh to use this directory instead by exporting the `BASH_OTP_TOKENFILES_DIR` variable like so:
+
+  ```bash
+  $ export BASH_OTP_TOKENFILES_DIR=/path/to/secure/tokenfiles/dir
+  ```
 
 ## Contents
 

--- a/otp.sh
+++ b/otp.sh
@@ -9,7 +9,7 @@
 #openssl enc -aes-256-cbc -d -salt -in file.txt.enc -out file.txt
 
 # Init
-TOKENFILES_DIR=${BASH_OTP_TOKENFILES_DIR:-"$( dirname ${0} )/tokenfiles"}
+TOKENFILES_DIR="${BASH_OTP_TOKENFILES_DIR:-$( dirname ${0} )/tokenfiles}"
 TOKENFILES_DIR_MODE="$( ls -ld ${TOKENFILES_DIR} | awk '{print $1}'| sed 's/.//' )"
 U_MODE="$( echo $TOKENFILES_DIR_MODE | gawk  -F '' '{print $1 $2 $3}' )"
 G_MODE="$( echo $TOKENFILES_DIR_MODE | gawk  -F '' '{print $4 $5 $6}' )"

--- a/otp.sh
+++ b/otp.sh
@@ -9,7 +9,7 @@
 #openssl enc -aes-256-cbc -d -salt -in file.txt.enc -out file.txt
 
 # Init
-TOKENFILES_DIR="$( dirname ${0} )/tokenfiles"
+TOKENFILES_DIR=${BASH_OTP_TOKENFILES_DIR:-"$( dirname ${0} )/tokenfiles"}
 TOKENFILES_DIR_MODE="$( ls -ld ${TOKENFILES_DIR} | awk '{print $1}'| sed 's/.//' )"
 U_MODE="$( echo $TOKENFILES_DIR_MODE | gawk  -F '' '{print $1 $2 $3}' )"
 G_MODE="$( echo $TOKENFILES_DIR_MODE | gawk  -F '' '{print $4 $5 $6}' )"


### PR DESCRIPTION
This adds a `BASH_OTP_TOKENFILES_DIR` environment variable that the user
can set to customize the location of token files.  This allows the *.sh
scripts to work outside of the repo directory, for installation in
e.g. bash-it/zplug/antigen as managed commands.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/poolpog/bash-otp/4)
<!-- Reviewable:end -->
