### PR TITLE
RFC: Add binary location independent wrapper and installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+PREFIX_DIR="${HOME}/.local/"
+APP_DIR="${PWD}"
+
+
+install:
+	ln -nsf $(APP_DIR)/otp $(PREFIX_DIR)/bin/

--- a/otp
+++ b/otp
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+ROOT="$(dirname "$(readlink -f ${0})")"
+cd "$ROOT"
+exec "$ROOT"/otp.sh "${@}"


### PR DESCRIPTION
This adds a wrapper around otp.sh that when linked to another location calls otp.sh with its install location.
That is when you link otp to a directory in your PATH you can call "otp" and have it resolve the token location (otp wrapper has to be still located in the same directory as otp.sh and tokenfiles).
The Makefile is pretty bare as it only link the otp wrapper in the user $HOME/.local/bin location.
From https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html this directory should be in the PATH of user sessions already.
Still user might want to "install" otp to other location.
